### PR TITLE
Set default message digest to sha256

### DIFF
--- a/lib/CA.pm
+++ b/lib/CA.pm
@@ -349,7 +349,7 @@ sub get_ca_create {
       $opts = {};
       $opts->{'days'} = 3650; # set default to 10 years
       $opts->{'bits'} = 4096;
-      $opts->{'digest'} = 'sha1';
+      $opts->{'digest'} = 'sha256';
 
       if(defined($mode) && $mode eq "sub") { # create SubCA, use defaults
          $opts->{'parentca'} = $main->{'CA'}->{'actca'};
@@ -453,7 +453,7 @@ sub get_ca_import {
       $opts = {};
       $opts->{'days'} = 3650; # set default to 10 years
       $opts->{'bits'} = 4096;
-      $opts->{'digest'} = 'sha1';
+      $opts->{'digest'} = 'sha256';
       
       $main->show_ca_import_dialog($opts);
       return;

--- a/templates/openssl.cnf
+++ b/templates/openssl.cnf
@@ -15,7 +15,7 @@ RANDFILE        = $dir/.rand
 x509_extensions = client_cert
 default_days    = 365
 default_crl_days= 30
-default_md      = sha1
+default_md      = sha256
 preserve        = no
 policy          = policy_client
 
@@ -33,7 +33,7 @@ RANDFILE        = $dir/.rand
 x509_extensions = server_cert
 default_days    = 365
 default_crl_days= 30
-default_md      = sha1
+default_md      = sha256
 preserve        = no
 policy          = policy_server
 
@@ -51,7 +51,7 @@ RANDFILE        = $dir/.rand
 x509_extensions = v3_ca
 default_days    = 365
 default_crl_days= 30
-default_md      = sha1
+default_md      = sha256
 preserve        = no
 policy          = policy_ca
 


### PR DESCRIPTION
This commit contains the changes necessary to set the default digest for new CAs and SubCAs to sha256.
